### PR TITLE
Don't set the SessionID if the session has already started

### DIFF
--- a/src/Session/Middleware.php
+++ b/src/Session/Middleware.php
@@ -89,7 +89,7 @@ class Middleware implements HttpKernelInterface
 
 		$sessionName = $this->session->getName();
 
-		if ($request->cookies->has($sessionName)) {
+		if ($request->cookies->has($sessionName) && !$this->session->isStarted()) {
 			$this->session->setId($request->cookies->get($sessionName));
 		} else {
 			$this->session->migrate(false);


### PR DESCRIPTION
Ran into a small bug when modifying the Session data in a ServiceProvider.

When the session cookie is set, it tries to set the Session ID which is already started, resulting in an error saying "Cannot change the ID of an active session."  Checking to make sure the session hasn't already started resolved this for me
