### PR TITLE
Convert route filters into event listeners

### DIFF
--- a/src/Routing/Events/AbstractRouteEvent.php
+++ b/src/Routing/Events/AbstractRouteEvent.php
@@ -1,0 +1,55 @@
+<?php
+/**
+ * This file is part of the Autarky package.
+ *
+ * (c) Andreas Lutro <anlutro@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Autarky\Routing\Events;
+
+use Symfony\Component\EventDispatcher\Event;
+use Symfony\Component\HttpFoundation\Request;
+
+use Autarky\Routing\Route;
+
+class AbstractRouteEvent extends Event
+{
+	/**
+	 * @var Request
+	 */
+	protected $request;
+
+	/**
+	 * @var Route
+	 */
+	protected $route;
+
+	public function __construct(Request $request, Route $route)
+	{
+		$this->request = $request;
+		$this->route = $route;
+	}
+
+	/**
+	 * Get the request instance.
+	 *
+	 * @return Request
+	 */
+	public function getRequest()
+	{
+		return $this->request;
+	}
+
+	/**
+	 * Get the route instance.
+	 *
+	 * @return Route
+	 */
+	public function getRoute()
+	{
+		return $this->route;
+	}
+}

--- a/src/Routing/Events/AfterFilterEvent.php
+++ b/src/Routing/Events/AfterFilterEvent.php
@@ -1,0 +1,37 @@
+<?php
+/**
+ * This file is part of the Autarky package.
+ *
+ * (c) Andreas Lutro <anlutro@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Autarky\Routing\Events;
+
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
+
+use Autarky\Routing\Route;
+
+class AfterFilterEvent extends AbstractRouteEvent
+{
+	protected $response;
+
+	public function __construct(Request $request, Route $route, Response $response)
+	{
+		parent::__construct($request, $route);
+		$this->response = $response;
+	}
+
+	public function setResponse(Response $response)
+	{
+		$this->response = $response;
+	}
+
+	public function getResponse()
+	{
+		return $this->response;
+	}
+}

--- a/src/Routing/Events/BeforeFilterEvent.php
+++ b/src/Routing/Events/BeforeFilterEvent.php
@@ -1,0 +1,37 @@
+<?php
+/**
+ * This file is part of the Autarky package.
+ *
+ * (c) Andreas Lutro <anlutro@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Autarky\Routing\Events;
+
+class BeforeFilterEvent extends AbstractRouteEvent
+{
+	protected $controller;
+	protected $response;
+
+	public function setController($controller)
+	{
+		$this->controller = $controller;
+	}
+
+	public function getController()
+	{
+		return $this->controller;
+	}
+
+	public function setResponse($response)
+	{
+		$this->response = $response;
+	}
+
+	public function getResponse()
+	{
+		return $this->response;
+	}
+}

--- a/src/Routing/Events/RouteMatchedEvent.php
+++ b/src/Routing/Events/RouteMatchedEvent.php
@@ -10,50 +10,6 @@
 
 namespace Autarky\Routing\Events;
 
-use Symfony\Component\EventDispatcher\Event;
-use Symfony\Component\HttpFoundation\Request;
-
-use Autarky\Routing\Route;
-
-class RouteMatchedEvent extends Event
+class RouteMatchedEvent extends AbstractRouteEvent
 {
-	/**
-	 * The request the route was matched against.
-	 *
-	 * @var Request
-	 */
-	protected $request;
-
-	/**
-	 * The route the request was matched with.
-	 *
-	 * @var Route
-	 */
-	protected $route;
-
-	public function __construct(Request $request, Route $route)
-	{
-		$this->request = $request;
-		$this->route = $route;
-	}
-
-	/**
-	 * Get the request instance.
-	 *
-	 * @return Request
-	 */
-	public function getRequest()
-	{
-		return $this->request;
-	}
-
-	/**
-	 * Get the route instance.
-	 *
-	 * @return Route
-	 */
-	public function getRoute()
-	{
-		return $this->route;
-	}
 }

--- a/src/Routing/Route.php
+++ b/src/Routing/Route.php
@@ -38,9 +38,9 @@ class Route
 	protected $pattern;
 
 	/**
-	 * @var string|\Closure
+	 * @var callable
 	 */
-	protected $handler;
+	protected $controller;
 
 	/**
 	 * @var null|string
@@ -58,17 +58,22 @@ class Route
 	protected $afterFilters = [];
 
 	/**
-	 * @param array  $methods HTTP methods allowed for this route
-	 * @param string $pattern
-	 * @param mixed  $handler
-	 * @param string $name
+	 * @param array    $methods    HTTP methods allowed for this route
+	 * @param string   $pattern
+	 * @param callable $controller
+	 * @param string   $name
 	 */
-	public function __construct(array $methods, $pattern, $handler, $name = null)
+	public function __construct(array $methods, $pattern, $controller, $name = null)
 	{
 		$this->methods = $methods;
 		$this->pattern = $pattern;
-		$this->handler = $handler;
 		$this->name = $name;
+
+		if (is_string($controller) && !is_callable($controller)) {
+			$controller = \Autarky\splitclm($controller, 'action');
+		}
+
+		$this->controller = $controller;
 	}
 
 	/**
@@ -100,16 +105,6 @@ class Route
 	}
 
 	/**
-	 * Get the handler for the route.
-	 *
-	 * @return \Closure|string
-	 */
-	public function getHandler()
-	{
-		return $this->handler;
-	}
-
-	/**
 	 * Get the route's name.
 	 *
 	 * @return string|null
@@ -122,7 +117,7 @@ class Route
 	/**
 	 * Add a before filter.
 	 *
-	 * @param mixed $filter
+	 * @param string $filter
 	 */
 	public function addBeforeFilter($filter)
 	{
@@ -132,7 +127,7 @@ class Route
 	/**
 	 * Add an after filter.
 	 *
-	 * @param mixed $filter
+	 * @param string $filter
 	 */
 	public function addAfterFilter($filter)
 	{
@@ -142,8 +137,8 @@ class Route
 	/**
 	 * Add a before or after filter.
 	 *
-	 * @param string $when   "before" or "after"
-	 * @param mixed  $filter
+	 * @param string  $when   "before" or "after"
+	 * @param string  $filter
 	 */
 	public function addFilter($when, $filter)
 	{
@@ -153,7 +148,7 @@ class Route
 	/**
 	 * Get the route's before filters.
 	 *
-	 * @return array
+	 * @return string[]
 	 */
 	public function getBeforeFilters()
 	{
@@ -163,25 +158,16 @@ class Route
 	/**
 	 * Get the route's after filters.
 	 *
-	 * @return array
+	 * @return string[]
 	 */
 	public function getAfterFilters()
 	{
 		return $this->afterFilters;
 	}
 
-	/**
-	 * Get the route callable.
-	 *
-	 * @return mixed
-	 */
-	public function getCallable()
+	public function getController()
 	{
-		if (is_callable($this->handler)) {
-			return $this->handler;
-		}
-
-		return \Autarky\splitclm($this->handler, 'action');
+		return $this->controller;
 	}
 
 	/**

--- a/src/Routing/Router.php
+++ b/src/Routing/Router.php
@@ -28,14 +28,17 @@ use Autarky\Events\EventDispatcherAwareTrait;
 /**
  * FastRoute implementation of the router.
  */
-class Router implements RouterInterface, EventDispatcherAwareInterface
+class Router implements RouterInterface
 {
-	use EventDispatcherAwareTrait;
-
 	/**
 	 * @var \Autarky\Routing\InvokerInterface
 	 */
 	protected $invoker;
+
+	/**
+	 * @var EventDispatcherInterface
+	 */
+	protected $eventDispatcher;
 
 	/**
 	 * @var \FastRoute\RouteCollector
@@ -82,12 +85,17 @@ class Router implements RouterInterface, EventDispatcherAwareInterface
 	protected $namedRoutes = [];
 
 	/**
-	 * @param InvokerInterface $invoker
-	 * @param string|null      $cachePath
+	 * @param InvokerInterface         $invoker
+	 * @param EventDispatcherInterface $eventDispatcher
+	 * @param string|null              $cachePath
 	 */
-	public function __construct(InvokerInterface $invoker, $cachePath = null)
-	{
+	public function __construct(
+		InvokerInterface $invoker,
+		EventDispatcherInterface $eventDispatcher,
+		$cachePath = null
+	) {
 		$this->invoker = $invoker;
+		$this->eventDispatcher = $eventDispatcher;
 
 		if ($cachePath) {
 			$this->cachePath = $cachePath;
@@ -111,16 +119,27 @@ class Router implements RouterInterface, EventDispatcherAwareInterface
 		return $this->currentRoute;
 	}
 
+	public function addBeforeFilter($name, $handler, $priority = 0)
+	{
+		$this->addFilter($name, $handler, 'before', $priority);
+	}
+
+	public function addAfterFilter($name, $handler, $priority = 0)
+	{
+		$this->addFilter($name, $handler, 'after', $priority);
+	}
+
 	/**
 	 * {@inheritdoc}
 	 */
-	public function defineFilter($name, $handler)
+	public function addFilter($name, $handler, $when, $priority)
 	{
 		if (array_key_exists($name, $this->filters)) {
 			throw new \LogicException("Filter with name $name already defined");
 		}
 
-		$this->filters[$name] = $handler;
+		$this->filters[$name] = $name;
+		$this->eventDispatcher->addListener("route.$when.$name", $handler, $priority);
 	}
 
 	/**
@@ -253,11 +272,7 @@ class Router implements RouterInterface, EventDispatcherAwareInterface
 
 		switch ($result[0]) {
 			case \FastRoute\Dispatcher::FOUND:
-				$args = [];
-				foreach ($result[2] as $key => $value) {
-					$args["\$$key"] = $value;
-				}
-				return $this->getResponse($request, $result[1], $args);
+				return $this->getResponse($request, $result[1], $result[2]);
 
 			case \FastRoute\Dispatcher::NOT_FOUND:
 				throw new NotFoundHttpException('No route match for path '.$request->getPathInfo() ?: '/');
@@ -271,8 +286,14 @@ class Router implements RouterInterface, EventDispatcherAwareInterface
 		}
 	}
 
-	protected function getResponse(Request $request, Route $route, array $args)
+	protected function getResponse(Request $request, Route $route, array $originalArgs)
 	{
+		$params = [];
+		foreach ($originalArgs as $key => $value) {
+			$params["\$$key"] = $value;
+		}
+		$params['Symfony\Component\HttpFoundation\Request'] = $request;
+
 		if ($this->eventDispatcher !== null) {
 			$event = new Events\RouteMatchedEvent($request, $route);
 			$this->eventDispatcher->dispatch('route.match', $event);
@@ -280,16 +301,23 @@ class Router implements RouterInterface, EventDispatcherAwareInterface
 
 		$this->currentRoute = $route;
 
+		$event = new Events\BeforeFilterEvent($request, $route);
+		$this->eventDispatcher->dispatch("route.before", $event);
 		foreach ($route->getBeforeFilters() as $filter) {
-			if ($response = $this->callFilter($filter, $route, $request)) {
-				return $this->makeResponse($response);
-			}
+			$this->eventDispatcher->dispatch("route.before.$filter", $event);
 		}
 
-		$response = $this->makeResponse($this->callRoute($route, $request, $args));
+		if ($response = $event->getResponse()) {
+			$response = $this->makeResponse($response);
+		} else {
+			$callable = $event->getController() ?: $route->getController();
+			$response = $this->makeResponse($this->invoker->invoke($callable, $params));
+		}
 
+		$event = new Events\AfterFilterEvent($request, $route, $response);
+		$this->eventDispatcher->dispatch("route.after", $event);
 		foreach ($route->getAfterFilters() as $filter) {
-			$this->callFilter($filter, $route, $request, $response);
+			$this->eventDispatcher->dispatch("route.after.$filter", $event);
 		}
 
 		return $response;
@@ -298,42 +326,6 @@ class Router implements RouterInterface, EventDispatcherAwareInterface
 	protected function makeResponse($result)
 	{
 		return $result instanceof Response ? $result : new Response($result);
-	}
-
-	protected function callRoute(Route $route, Request $request, array $args)
-	{
-		$args['Symfony\Component\HttpFoundation\Request'] = $request;
-
-		return $this->invoker->invoke($route->getCallable(), $args);
-	}
-
-	protected function callFilter($filter, Route $route, Request $request, Response $response = null)
-	{
-		$params = [
-			'Autarky\Routing\Route' => $route,
-			'Symfony\Component\HttpFoundation\Request' => $request,
-			'Symfony\Component\HttpFoundation\Response' => $response,
-		];
-
-		if (is_array($filter)) {
-			$responder = $this->getCallable($filter[1], 'respond');
-			$filter = $this->getCallable($filter[0], 'filter');
-			$shouldRespond = $this->invoker->invoke($filter, $params);
-			if ($shouldRespond) {
-				return $this->invoker->invoke($responder, $params);
-			}
-		} else {
-			$filter = $this->getCallable($filter, 'filter');
-			return $this->invoker->invoke($filter, $params);
-		}
-	}
-
-	protected function getCallable($callable, $defaultMethod)
-	{
-		if (is_string($callable) && !is_callable($callable)) {
-			return \Autarky\splitclm($callable, $defaultMethod);
-		}
-		return $callable;
 	}
 
 	protected function getDispatcher()

--- a/src/Routing/RouterInterface.php
+++ b/src/Routing/RouterInterface.php
@@ -56,16 +56,6 @@ interface RouterInterface
 	public function getCurrentRoute();
 
 	/**
-	 * Define a filter.
-	 *
-	 * @param  string           $name
-	 * @param  \Closure|string  $handler
-	 *
-	 * @return void
-	 */
-	public function defineFilter($name, $handler);
-
-	/**
 	 * Define a route group.
 	 *
 	 * @param  array    $flags    Valid keys are 'before', 'after', 'prefix'

--- a/src/Routing/RoutingProvider.php
+++ b/src/Routing/RoutingProvider.php
@@ -30,6 +30,7 @@ class RoutingProvider extends ServiceProvider
 		$dic->define('Autarky\Routing\Router', function(ContainerInterface $container) {
 			return new Router(
 				$container->resolve('Autarky\Routing\Invoker'),
+				$container->resolve('Symfony\Component\EventDispatcher\EventDispatcherInterface'),
 				$this->app->getConfig()->get('path.route_cache')
 			);
 		});

--- a/tests/src/Routing/RouteTest.php
+++ b/tests/src/Routing/RouteTest.php
@@ -32,11 +32,11 @@ class RouteTest extends PHPUnit_Framework_TestCase
 	}
 
 	/** @test */
-	public function callableIsEqualWithStringAndArray()
+	public function controllerIsEqualWithStringAndArray()
 	{
 		$route1 = new Route([], '', __NAMESPACE__.'\RouteHandlerStub:handle');
 		$route2 = new Route([], '', [__NAMESPACE__.'\RouteHandlerStub', 'handle']);
-		$this->assertEquals($route1->getCallable(), $route2->getCallable());
+		$this->assertEquals($route1->getController(), $route2->getController());
 	}
 }
 

--- a/tests/src/Routing/ServiceProviderTest.php
+++ b/tests/src/Routing/ServiceProviderTest.php
@@ -8,7 +8,10 @@ class ServiceProviderTest extends TestCase
 {
 	protected function checkResolve($class)
 	{
-		$app = $this->makeApplication('Autarky\Routing\RoutingProvider');
+		$app = $this->makeApplication([
+			'Autarky\Events\EventDispatcherProvider',
+			'Autarky\Routing\RoutingProvider'
+		]);
 		$app->boot();
 		$object = $app->getContainer()->resolve($class);
 		$this->assertInstanceOf($class, $object);

--- a/tests/src/Routing/UrlGeneratorTest.php
+++ b/tests/src/Routing/UrlGeneratorTest.php
@@ -6,6 +6,8 @@ use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\RequestStack;
 
 use Autarky\Container\Container;
+use Autarky\Events\EventDispatcher;
+use Autarky\Events\ListenerResolver;
 use Autarky\Routing\Router;
 use Autarky\Routing\Invoker;
 use Autarky\Routing\UrlGenerator;
@@ -14,7 +16,11 @@ class UrlGeneratorTest extends PHPUnit_Framework_TestCase
 {
 	public function makeRouterAndGenerator($request = null)
 	{
-		$router = new Router(new Invoker(new Container));
+		$container = new Container;
+		$router = new Router(
+			new Invoker($container),
+			new EventDispatcher(new ListenerResolver($container))
+		);
 		$requests = new RequestStack;
 		if ($request) $requests->push($request);
 		return [$router, new UrlGenerator($router, $requests)];


### PR DESCRIPTION
#### Event methods

`getRequest()`, `getRoute()` are available on all events.

"before" events also have `setResponse(mixed $response)` and `setController(callable $controller)`.

"after" events have `setResponse(Response $response)`.
#### Replacing responses in before filters

Before:

``` php
$router->defineFilter('foo', function() { return 'filter response'; });
```

After:

``` php
//   ... or onAfter
$router->onBefore('foo', function($event) {
    $event->setResponse('filter response');
});
```
### Replacing the controller with a custom responder

Before:

``` php
class MyFilter {
    public function filter() {
        return ($something === true);
    }
}

class MyResponder {
    public function respond() {
        return 'filter response';
    }
}

$router->defineFilter('foo', ['MyFilter:filter', 'MyResponder:respond']);
```

After:

``` php
class MyResponder {
    public function respond() {
        return 'filter response';
    }
}

$router->onBefore('foo', function($event) {
    if ($something === true) {
        $event->setController(['MyResponder', 'respond']);
    }
});
```
